### PR TITLE
[#657] generate deltas via CLI

### DIFF
--- a/galter_subjects_utils/contrib/mesh/converter.py
+++ b/galter_subjects_utils/contrib/mesh/converter.py
@@ -195,7 +195,8 @@ class MeSHSubjectDeltasConverter:
                 "scheme": self.scheme,
                 "id": generate_id(a.id),
                 "subject": a.label
-            } for a in self._additions
+            }
+            for a in self._additions
         )
 
         # Renames
@@ -203,10 +204,11 @@ class MeSHSubjectDeltasConverter:
             {
                 "type": "rename",
                 "scheme": self.scheme,
-                "id": generate_id(id_),
+                "id": generate_id(analysis.id),
+                "subject": label,
                 "new_subject": analysis.relabelled
             }
-            for id_, analysis in self._id_to_analysis.items()
+            for label, analysis in self._label_to_analysis.items()
             if analysis.relabelled
         )
 
@@ -215,10 +217,11 @@ class MeSHSubjectDeltasConverter:
             {
                 "type": "replace",
                 "scheme": self.scheme,
-                "id": generate_id(id_),
+                "id": generate_id(analysis.id),
+                "subject": label,
                 "new_id": generate_id(analysis.replaced)
             }
-            for id_, analysis in self._id_to_analysis.items()
+            for label, analysis in self._label_to_analysis.items()
             if analysis.replaced
         )
 
@@ -227,8 +230,10 @@ class MeSHSubjectDeltasConverter:
             {
                 "type": "remove",
                 "scheme": self.scheme,
-                "id": generate_id(id_),
-            } for id_, analysis in self._id_to_analysis.items()
+                "id": generate_id(analysis.id),
+                "subject": label
+            }
+            for label, analysis in self._label_to_analysis.items()
             if not analysis.seen and not analysis.replaced
         )
 

--- a/galter_subjects_utils/reader.py
+++ b/galter_subjects_utils/reader.py
@@ -8,6 +8,7 @@
 
 """Generic reader functionality."""
 
+import csv
 import json
 
 from invenio_db import db
@@ -20,6 +21,14 @@ def read_jsonl(filepath):
     with open(filepath) as f:
         for line in f:
             yield json.loads(line)
+
+
+def read_csv(filepath, reader_kwargs=None):
+    """KISS csv reader."""
+    reader_kwargs = reader_kwargs or {}
+    with open(filepath) as f:
+        reader = csv.DictReader(f, **reader_kwargs)
+        yield from reader
 
 
 def mapping_by(iterable, by, keys=None):
@@ -42,7 +51,6 @@ def mapping_by(iterable, by, keys=None):
 
 def get_rdm_subjects(scheme):
     """Return all rdm subjects of corresponding scheme."""
-
     is_scheme = (
         text('json::json->>\'scheme\' = :scheme')
         .bindparams(

--- a/galter_subjects_utils/writer.py
+++ b/galter_subjects_utils/writer.py
@@ -31,6 +31,15 @@ def write_jsonl(
     return filepath
 
 
+def write_csv(entries, filepath, writer_kwargs=None):
+    """Write to CSV."""
+    writer_kwargs = writer_kwargs or {}
+    with open(filepath, "w") as f:
+        writer = csv.DictWriter(f, **writer_kwargs)
+        writer.writeheader()
+        writer.writerows(entries)
+
+
 class SubjectDeltaLogger:
     """Convenience logger for delta operations applied to records."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "click>=7.0,<9.0",
     "invenio-access>=1.4.4,<2.0.0",
-    "invenio-db[postgresql]>=1.1.5,<2.0.0",
+    "invenio-db[postgresql]>=1.0.14,<1.1.0",
     # invenio-db provides sqlalchemy & co
     "invenio-i18n<2.0.0",  # required for v11
     "invenio-rdm-records[opensearch2]>=1.1.0,<2.0.0",
@@ -53,6 +53,11 @@ dev = [
     "pytest-invenio>=2.1.1,<3.0.0",
     # pytest-invenio includes pytest & co and docker-services-cli
 ]
+
+
+[project.entry-points."flask.commands"]
+galter_subjects = "galter_subjects_utils.cli:main"
+
 
 # Only setuptools usage
 [tool.setuptools]

--- a/tests/contrib/mesh/test_converter.py
+++ b/tests/contrib/mesh/test_converter.py
@@ -186,9 +186,10 @@ def test_converter_rename():
 
     expected = [
         {
-            "type": "rename",
             "id": "https://id.nlm.nih.gov/mesh/D017394",
+            "type": "rename",
             "scheme": "MeSH",
+            "subject": "RNA, Guide",
             "new_subject": "RNA, Guide, Kinetoplastida"
         },
     ]
@@ -223,21 +224,23 @@ def test_converter_replace():
     expected = [
         # contains add operation since replacement is new
         {
-            "type": "add",
             "id": "https://id.nlm.nih.gov/mesh/foo-after",
+            "type": "add",
             "scheme": "MeSH",
             "subject": "Foo after"
         },
         {
-            "type": "replace",
             "id": "https://id.nlm.nih.gov/mesh/D000086562Q000145",
+            "type": "replace",
             "scheme": "MeSH",
+            "subject": "American Indians or Alaska Natives/classification",
             "new_id": "https://id.nlm.nih.gov/mesh/D044467Q000145"
         },
         {
-            "type": "replace",
             "id": "https://id.nlm.nih.gov/mesh/foo-before",
+            "type": "replace",
             "scheme": "MeSH",
+            "subject": "Foo before",
             "new_id": "https://id.nlm.nih.gov/mesh/foo-after"
         },
     ]
@@ -256,9 +259,10 @@ def test_converter_remove():
 
     expected = [
         {
-            "type": "remove",
             "id": "https://id.nlm.nih.gov/mesh/" + subject.id,
+            "type": "remove",
             "scheme": "MeSH",
+            "subject": "Epigenesis, Genetic/ethics",
         },
     ]
     assert expected == ops


### PR DESCRIPTION
- closes https://github.com/galterlibrary/Prism/issues/657
- The idea is for a curator to mark in the `keep_trace` column which subject renaming/replacing/removing should be "kept trace of"
- Then subsequent PR will introduce update CLI command with `--keep-trace-field` and `--keep-trace-template` parameters to keep trace of those subjects on records.